### PR TITLE
Match arguments.

### DIFF
--- a/lib/petl.rb
+++ b/lib/petl.rb
@@ -13,11 +13,11 @@ module Petl
     raise NotImplementedError.new "#{self}#extract not implemented."
   end
 
-  def transform
+  def transform(_rows)
     raise NotImplementedError.new "#{self}#transform not implemented."
   end
 
-  def load
+  def load(_rows)
     raise NotImplementedError.new "#{self}#load not implemented."
   end
 


### PR DESCRIPTION
If the base method doesn't take the same arguments we'll get an
ArgumentError instead of the expected NotImplementedError (in case we
forgot to implement `transform` or `load`).
